### PR TITLE
Initialisation d'une base pour les slides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build shell test all
+.PHONY: build shell test all presentation
 
 DOCKER_IMAGE := cpt_igloo/devbox
 
@@ -9,6 +9,10 @@ build:
 
 shell:
 	docker run --rm --tty --interactive "$(DOCKER_IMAGE)" /bin/bash -l
+
+presentation:
+	docker run -d -v $(CURDIR)/slides:/www -p 80:80 fnichol/uhttpd
+	@echo http://$$(boot2docker ip 2>/dev/null):80
 
 test:
 	docker run \

--- a/slides/index.html
+++ b/slides/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Title</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+	<style type="text/css">
+		@import url(http://fonts.googleapis.com/css?family=Yanone+Kaffeesatz);
+		@import url(http://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic);
+		@import url(http://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700,400italic);
+
+		body { font-family: 'Droid Serif'; }
+		h1, h2, h3 {
+			font-family: 'Yanone Kaffeesatz';
+			font-weight: normal;
+		}
+		.remark-code, .remark-inline-code { font-family: 'Ubuntu Mono'; }
+	</style>
+</head>
+<body>
+	<script src="http://gnab.github.io/remark/downloads/remark-latest.min.js" type="text/javascript">
+	</script>
+	<script type="text/javascript">
+		var slideshow = remark.create({
+			sourceUrl: 'slides.md'
+		});
+	</script>
+</body>
+</html>

--- a/slides/slides.md
+++ b/slides/slides.md
@@ -1,0 +1,15 @@
+class: center, middle
+
+# Title
+
+---
+
+# Agenda
+
+1. Introduction
+2. Deep-dive
+3. ...
+
+---
+
+# Introduction


### PR DESCRIPTION
- Je propose d'utiliser [Remark](http://remarkjs.com) qui permet de faire de jolies slides simplement, avec une base Markdown et un index.html minimaliste
- Dossier "slides" initialisé avec index.html + slides.md
- Ajout d'une cible `make presentation` pour lancer un webserver http basique et très léger (image Docker de 8 Mo), servant ainsi notre support de présentation. Pas de "auto-reload" à chaud, mais si on modifie le fichier slides.md, un coup de F5 va recharger le tout.
