### PR TITLE
Moving from XFCE to Lxde

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ RUN apt-key adv --recv-keys --keyserver keys.gnupg.net E1F958385BFE2B6E \
     vim \
     wget
 RUN apt-get install -y --no-install-recommends \
-    xfce4 \
-    xfce4-goodies \
+    lxde \
     x2goserver \
+    x2golxdebindings \
     x2goserver-xsession \
     x2go-keyring \
   && echo "root:root" | chpasswd \

--- a/TODO.md
+++ b/TODO.md
@@ -6,8 +6,6 @@
 * [ ] Script shell de lancement de la devbox (avec partage docker socket + docker bin)
 * [ ] Script de "backup" du workspace (docker run --volume-from=devbox debian:wheezy -v /vagrant:/backup tar czf /data /backup/$(date).tgz ou truc du genre) 
 
-* [ ] XFCE : "default config" to panel
-* [ ] XFCE raccourcis pour IntelliJ
-* [ ] Icones XFCE ?
+* [ ] LXDE raccourci pour IntelliJ avec image
 
 * [ ] Attention, les ENV du Dockerfile ne sont pas appliqués au user dockerx => /etc/default, profile, etc...

--- a/tests/bats/devbox-comon.bats
+++ b/tests/bats/devbox-comon.bats
@@ -16,3 +16,7 @@
 @test "Check that dockerx can sudo whithout password" {
 	docker run -u dockerx cpt_igloo/devbox:latest sudo whoami
 }
+
+@test "We use lxde" {
+	docker run -u dockerx cpt_igloo/devbox:latest which lxde-logout
+}


### PR DESCRIPTION
Since LXDE is lightweight and easier to configure.

Be careful to change your session type in X2Go from XFCE to LXDE also.
