### PR TITLE
Adding a web browser to the devbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Jean-Marc MEESSEN <jean-marc@meessen-web.org>
 ENV DEBIAN_FRONTEND noninteractive
 ENV IDEA_VERSION=14.1.1
 ENV MAVEN_VERSION=3.2.5
+ENV FIREFOX_VERSION=37.0.1
 
 COPY configs/x2go.list /etc/apt/sources.list.d/x2go.list
 
@@ -66,6 +67,13 @@ COPY configs/idea.png /opt/idea/idea.png
 USER dockerx
 COPY configs/lxde-main-panel /home/dockerx/.config/lxpanel/LXDE/panels/panel
 USER root
+COPY configs/idea.desktop /usr/share/applications/idea.desktop
+COPY configs/idea.png /opt/idea/idea.png
+
+RUN apt-get update && apt-get install -y --no-install-recommends libXrender1 libasound2 libdbus-glib-1-2 libgtk2.0-0 libpango1.0-0 libxt6 && apt-get remove -y iceweasel
+RUN cd /opt; wget -O - \
+    http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/latest/linux-x86_64/en-US/firefox-${FIREFOX_VERSION}.tar.bz2 | tar jx \
+    && ln -s /opt/firefox/firefox /usr/local/bin/
 
 EXPOSE 22
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,8 @@ RUN cd /opt; wget -O - \
     http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/latest/linux-x86_64/en-US/firefox-${FIREFOX_VERSION}.tar.bz2 | tar jx \
     && ln -s /opt/firefox/firefox /usr/local/bin/
 
+COPY configs/firefox.desktop /usr/share/applications/firefox.desktop
+
 EXPOSE 22
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,4 +10,9 @@
 * [x] LXDE IntelliJ dans main taskbar
 * [x] Main taskbar en haut de l'écran
 
-* [ ] Attention, les ENV du Dockerfile ne sont pas appliqués au user dockerx => /etc/default, profile, etc...
+* [x] Ajout d'un navigateur web
+* [ ] Ajout d'un raccourci pour le terminal dans la taskbar
+
+* [x] Attention, les ENV du Dockerfile ne sont pas appliqués au user dockerx => /etc/default, profile, etc...
+
+* [ ] Lighten the final image

--- a/configs/firefox.desktop
+++ b/configs/firefox.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Mozilla Firefox
+Comment=A modern web browser
+Icon=/opt/firefox/browser/icons/mozicon128.png
+Exec=/usr/local/bin/firefox
+Type=Application
+Terminal=false
+Categories=Network;WebBrowser;

--- a/configs/lxde-main-panel
+++ b/configs/lxde-main-panel
@@ -53,7 +53,7 @@ Plugin {
             id=pcmanfm.desktop
         }
         Button {
-            id=lxde-x-www-browser.desktop
+            id=firefox.desktop
         }
         Button {
             id=idea.desktop

--- a/tests/bats/devbox-comon.bats
+++ b/tests/bats/devbox-comon.bats
@@ -63,6 +63,8 @@ teardown() {
 	teardown
 	run_as_user_cmd_in_devbox "dockerx" [ -f /home/dockerx/.config/lxpanel/LXDE/panels/panel ]
 	teardown
+	run_as_user_cmd_in_devbox "dockerx" [ -f /usr/share/applications/firefox.desktop ]
+	teardown
 	[ $(run_as_user_cmd_in_devbox "dockerx" grep 'firefox.desktop' /home/dockerx/.config/lxpanel/LXDE/panels/panel | wc -l) -ge 1 ]
 }
 


### PR DESCRIPTION
This PR need that https://github.com/jmMeessen/devbox/pull/9 has been merged.

It install ice weasel (a firefox fork) inside the devbox, in order to have a web browser.
