### PR TITLE
Improving Makefile and devbox workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build shell test all presentation start
+.PHONY: build shell test all presentation start clean
 
 DOCKER_IMAGE := cpt_igloo/devbox
 DOCKER_NAME = devbox
@@ -10,6 +10,7 @@ build:
 
 start:
 	docker start $(DOCKER_NAME) 2>/dev/null || docker run \
+		--name $(DOCKER_NAME) \
 		-d \
 		-p 2200:22 \
 		-v $$(which docker):$$(which docker) \
@@ -21,7 +22,7 @@ shell:
 	docker exec --tty --interactive $(DOCKER_NAME) sudo -u dockerx bash -l
 
 presentation:
-	docker run -d -v $(CURDIR)/slides:/www -p 80:80 fnichol/uhttpd
+	@docker run -d -v $(CURDIR)/slides:/www -p 80:80 fnichol/uhttpd
 	@echo http://$$(boot2docker ip 2>/dev/null):80
 
 test:
@@ -32,3 +33,7 @@ test:
 		-e DOCKER_HOST=unix:///var/run/docker.sock \
 		dduportal/bats:0.4.0 \
 			/bats-tests/
+
+clean:
+	docker kill devbox
+	docker rm devbox

--- a/README.md
+++ b/README.md
@@ -13,16 +13,21 @@ Note: It is assumed that you have a Docker environment installed (or alternative
 
 To use the Devbox a X client is needed. We chose "X2GO". The client part must be available on your machine.
 
-Start the Devbox container with `docker run -d  -P  cpt_igloo/devbox`.
+Start the Devbox container with :
+```bash
+$ make start
+```
+
+### Use the GUI 
 
 Start the X2GO client and configure a session by taking care to setup
 
 - the host to your boot2docker host (192.168.59.103)
 - the login to the devbox main user (dockerx)
-- the port to the assigned ssh port (use `docker ps` to display the redirected port for port 22)
-- set the session to LXDE
+- the port is statically assigned to localhost's 2200
+- set the session type to LXDE
 - in the "Connection" tab, choose "LAN" connection speed
-- in the "Input/output" tab, choose the display option that best suit your configuration.
+- (not mandatory because it will resize dynamically) in the "Input/output" tab, choose the display option that best suit your configuration.
 
 Save the session, and start it. 
 You will be prompted for a password. 
@@ -32,39 +37,66 @@ You will be prompted to accept the devbox public SSH key.
 If you restarted the container, the key might have changed and the SSH client will not like it.
 Follow the instructions to accept the new public key.
 
-If the system gives an error like "SSH daemon failed to open the application's public key", just
-accept it by clicking on "OK". 
+(Mac OS Yosemite Only bug) If the system gives an error like "SSH daemon failed to open the application's public key", just
+accept it by clicking on "OK".
+
 And, tadahh, your in business and connected to the GUI of your Devbox.
 
+### Use the command line
+
+You also access the devbox in command line with 2 solutions :
+
+* Use docker to spawn a new bash shell inside the devbox : 
+```bash
+$ make shell
+```
+* Use SSH to access the devbox : 
+```bash
+$ ssh dockerx@$(boot2docker ip 2>/dev/null) -p 2200
+```
 
 
-
-## How to build the Devbox
-
+## Advanced using : how to build/test/etc. the Devbox ?
 
 After getting the latest version of the box by cloning the Git repository, position yourself in the root of directory structure so that run the various commands.
 
-To create the Devbox (and run the automatic validation tests) execute : 
+* The full build and test workflow to create the Devbox : 
+```bash
+$ make
+```
 
- > make
+* To only rebuild image :
+```bash
+$ make build
+```
 
-To run the tests only, execute :
- > make test
+* To run the tests only, execute :
+```bash
+$ make test
+```
 
-To connect interactively to the Devbox, just execute :
+* To connect interactively to the Devbox, just execute :
+```bash
+$ make shell
+```
 
- > make shell
+* To delete your local devbox (and ERASE all your data...) :
+```bash
+$ make clean
+```
 
 
 ## How to run the presentation 
 
 (With Docker of course)
 
-To start a containerized web server that will generate the presentation:
+To start a containerized web server that will generate and serve the presentation locally :
 
- > make presentation 
+```bash
+$ make presentation 
+```
 
-To display it, start your favourite browser and point it to the Docker IP, port 80 (the address is echoed on the screen once the container is started).
+To display it, start your favourite browser and point it to the address echoed on the screen, once the container is started.
 
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 * [x] Sudoes no passwd
 * [x] Data volume à appliquer (/data, /tmp, logs, etc.) pour perfs I/O
 
-* [ ] Script shell de lancement de la devbox (avec partage docker socket + docker bin)
+* [x] Script shell de lancement de la devbox (avec partage docker socket + docker bin)
 * [ ] Script de "backup" du workspace (docker run --volume-from=devbox debian:wheezy -v /vagrant:/backup tar czf /data /backup/$(date).tgz ou truc du genre) 
 
 * [x] LXDE raccourci pour IntelliJ avec image
@@ -14,6 +14,8 @@
 * [x] Ajout d'un raccourci pour le terminal dans la taskbar
 
 * [x] Attention, les ENV du Dockerfile ne sont pas appliqués au user dockerx => /etc/default, profile, etc...
+
+* [ ] Test docker inside devbox
 
 * [ ] remove docker-bats directory
 * [ ] Lighten the final image


### PR DESCRIPTION
This PR introduce :
- Correction around the new `make start` command (naming container for reuse and persistence)
- A nicer `make presentation` output
- A new `make clean` (potentially dangerous) command that will delete your devbox and its data volumes (use case : after rebuilding, you need to delete your container to apply the new image)

README and TODO are updated also.  
